### PR TITLE
Remove propTypes; add TypeScript interfaces

### DIFF
--- a/src/js/containers/offcanvas/offcanvas.tsx
+++ b/src/js/containers/offcanvas/offcanvas.tsx
@@ -1,45 +1,37 @@
 import React from "react";
-import PropTypes from "prop-types";
 import Offcanvas from "bootstrap/js/dist/offcanvas";
 
 import { eventHandler, resolveRefs } from "dbl-utils";
 
 import JsonRender from "../../json-render";
-import Component from "../../component";
-import { ptClasses } from "../../prop-types";
+import Component, { ComponentProps } from "../../component";
 
 import schema from "./offcanvas.json";
+
+export interface OffcanvasContainerProps extends ComponentProps {
+  bodyClasses?: string | string[] | Record<string, any>;
+  closeClasses?: string | string[] | Record<string, any>;
+  footerClasses?: string | string[] | Record<string, any>;
+  headerClasses?: string | string[] | Record<string, any>;
+  labelClasses?: string | string[] | Record<string, any>;
+  label?: React.ReactNode;
+  labelTag?: string;
+  offcanvas?: Record<string, any>;
+  position?: "start" | "end" | "top" | "bottom";
+  showClose?: boolean;
+}
 
 /**
  * OffcanvasContainer component to manage and display an offcanvas UI element.
  * @extends Component
  */
-export default class OffcanvasContainer extends Component {
+export default class OffcanvasContainer extends Component<OffcanvasContainerProps> {
 
   // Static property to define the class name
   static jsClass = 'OffcanvasContainer';
 
-  static propTypes = {
-    ...Component.propTypes,
-    bodyClasses: ptClasses,
-    closeClasses: ptClasses,
-    footerClasses: ptClasses,
-    headerClasses: ptClasses,
-    labelClasses: ptClasses,
-    label: PropTypes.node,
-    labelTag: PropTypes.string,
-    offcanvas: PropTypes.object,
-    position: PropTypes.oneOf([
-      'start',
-      'end',
-      'top',
-      'bottom'
-    ]),
-    showClose: PropTypes.bool,
-  }
-
   // Default properties for the OffcanvasContainer component
-  static defaultProps = {
+  static defaultProps: Partial<OffcanvasContainerProps> = {
     ...Component.defaultProps,
     bodyClasses: '',
     closeClasses: '',

--- a/src/js/containers/panel-container/panel-container.tsx
+++ b/src/js/containers/panel-container/panel-container.tsx
@@ -1,27 +1,26 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 import { eventHandler } from "dbl-utils";
 import Component, { nameSuffixes } from "../../complex-component";
+import type { ComponentProps } from "../../component";
 
 import schema from "./panel-schema.json";
 
-export default class PanelContainer extends Component {
+export interface PanelContainerProps extends ComponentProps {
+  breakpoint?: string;
+  contentTop?: Record<string, any>;
+  icon?: string;
+  iconSize?: string | number;
+  link?: string;
+  logo?: string;
+  type?: "push" | "reveal";
+  width?: string | number;
+}
 
-  static propTypes = {
-    ...Component.propTypes,
-    breakpoint: PropTypes.string,
-    contentTop: PropTypes.object,
-    icon: PropTypes.string,
-    iconSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    link: PropTypes.string,
-    logo: PropTypes.string,
-    type: PropTypes.oneOf(['push', 'reveal']),
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  }
+export default class PanelContainer extends Component<PanelContainerProps> {
 
   static jsClass = 'PanelContainer';
-  static defaultProps = {
+  static defaultProps: Partial<PanelContainerProps> = {
     ...Component.defaultProps,
     schema,
     definitions: {},

--- a/src/js/forms/fields/drop-file-field.tsx
+++ b/src/js/forms/fields/drop-file-field.tsx
@@ -1,17 +1,16 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 import Field from "./field";
 
-export default class DropFileField extends Field {
+export interface DropFileFieldProps {
+  onDragOver?: (e: React.DragEvent<HTMLInputElement>) => void;
+  onDragLeave?: (e: React.DragEvent<HTMLInputElement>) => void;
+  onDrop?: (e: React.DragEvent<HTMLInputElement>) => void;
+}
+
+export default class DropFileField extends Field<DropFileFieldProps> {
 
   static jsClass = 'DropFileField';
-  static propTypes = {
-    ...Field.propTypes,
-    onDragOver: PropTypes.func,
-    onDragLeave: PropTypes.func,
-    onDrop: PropTypes.func
-  }
 
   constructor(props) {
     super(props);

--- a/src/js/forms/fields/field.tsx
+++ b/src/js/forms/fields/field.tsx
@@ -1,50 +1,51 @@
 import React, { Fragment, createRef } from "react";
-import PropTypes from "prop-types";
 
 import { randomS4, eventHandler } from "dbl-utils";
 
-import Component from "../../component";
+import Component, { ComponentProps } from "../../component";
 
-export default class Field extends Component {
+export interface FieldOption {
+  disabled?: boolean;
+  divider?: boolean;
+  label?: React.ReactNode | boolean | object | string;
+  value?: any;
+}
+
+export interface FieldProps extends ComponentProps {
+  accept?: string;
+  autoComplete?: string | boolean;
+  checkValidity?: (value: any) => boolean;
+  controlClasses?: string | string[];
+  default?: any;
+  disabled?: boolean;
+  errorMessage?: string | boolean | React.ReactNode;
+  first?: "label" | "control";
+  floating?: boolean;
+  hidden?: boolean;
+  inline?: boolean;
+  inlineControlClasses?: string | string[];
+  label?: string | React.ReactNode;
+  labelClasses?: string | string[];
+  max?: string | number;
+  message?: string | boolean | React.ReactNode;
+  messageClasses?: string | string[];
+  min?: string | number;
+  multiple?: boolean;
+  noValidate?: boolean;
+  pattern?: string;
+  placeholder?: string | React.ReactNode;
+  readOnly?: boolean;
+  required?: boolean;
+  step?: string | number;
+  type: string;
+  value?: any;
+  options?: FieldOption[];
+}
+
+export default class Field extends Component<FieldProps> {
 
   static jsClass = 'Field';
-  static propTypes = {
-    ...Component.propTypes,
-    accept: PropTypes.string,
-    autoComplete: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-    checkValidity: PropTypes.func,
-    controlClasses: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-    default: PropTypes.any,
-    disabled: PropTypes.bool,
-    errorMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.node]),
-    first: PropTypes.oneOf(['label', 'control']),
-    floating: PropTypes.bool,
-    hidden: PropTypes.bool,
-    inline: PropTypes.bool,
-    inlineControlClasses: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    labelClasses: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-    max: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    message: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.node]),
-    messageClasses: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-    min: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    multiple: PropTypes.bool,
-    noValidate: PropTypes.bool,
-    pattern: PropTypes.string,
-    placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    readOnly: PropTypes.bool,
-    required: PropTypes.bool,
-    step: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    type: PropTypes.string.isRequired,
-    value: PropTypes.any,
-    options: PropTypes.arrayOf(PropTypes.shape({
-      disabled: PropTypes.bool,
-      divider: PropTypes.bool,
-      label: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.bool, PropTypes.object]),
-      value: PropTypes.any,
-    })),
-  }
-  static defaultProps = {
+  static defaultProps: Partial<FieldProps> = {
     ...Component.defaultProps,
     type: 'text',
     default: '',

--- a/src/js/forms/fields/group-field.tsx
+++ b/src/js/forms/fields/group-field.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 
-import Field from "./field";
+import Field, { FieldProps } from "./field";
 
-export default class GroupField extends Field {
+export interface GroupFieldProps extends FieldProps {
+  groupClasses?: string;
+}
+
+export default class GroupField extends Field<GroupFieldProps> {
 
   static jsClass = 'GroupField';
-  static propTypes = {
-    ...Field.propTypes
-  }
-
-  static defaultProps = {
+  static defaultProps: Partial<GroupFieldProps> = {
     ...Field.defaultProps
   }
 

--- a/src/js/forms/fields/hidden-field.tsx
+++ b/src/js/forms/fields/hidden-field.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 
-import Field from "./field";
+import Field, { FieldProps } from "./field";
 
-export default class HiddenField extends Field {
+export interface HiddenFieldProps extends FieldProps {}
 
-  static propTypes = {
-    ...Field.propTypes
-  }
+export default class HiddenField extends Field<HiddenFieldProps> {
 
   static jsClass = 'HiddenField';
 

--- a/src/js/forms/fields/new-password-field.tsx
+++ b/src/js/forms/fields/new-password-field.tsx
@@ -1,30 +1,31 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 import { eventHandler } from "dbl-utils";
 
 import JsonRender from "../../json-render";
-import Field from "./field";
+import Field, { FieldProps } from "./field";
 import NoWrapField from "./no-wrap-field";
 
 
 //TODO: al cambiar parpadea la validación o.O
 
-export default class NewPasswordField extends Field {
+export interface NewPasswordFieldPattern {
+  pattern: string;
+  errorMessage: string;
+}
+
+export interface NewPasswordFieldProps extends FieldProps {
+  labelRepeat?: string | React.ReactNode;
+  placeholderRepeat?: string;
+  dividerClasses?: string;
+  patterns?: NewPasswordFieldPattern[];
+  mutations?: (data: any) => any;
+}
+
+export default class NewPasswordField extends Field<NewPasswordFieldProps> {
 
   static jsClass = 'NewPasswordField';
-  static propTypes = {
-    ...Field.propTypes,
-    labelRepeat: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    placeholderRepeat: PropTypes.string,
-    dividerClasses: PropTypes.string,
-    patterns: PropTypes.arrayOf(PropTypes.shape({
-      pattern: PropTypes.string,
-      errorMessage: PropTypes.string
-    })),
-    mutations: PropTypes.func
-  }
-  static defaultProps = {
+  static defaultProps: Partial<NewPasswordFieldProps> = {
     ...Field.defaultProps,
     dividerClasses: 'mb-3'
   }

--- a/src/js/forms/fields/no-wrap-field.tsx
+++ b/src/js/forms/fields/no-wrap-field.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 
-import Field from "./field";
+import Field, { FieldProps } from "./field";
 
-export default class NoWrapField extends Field {
+export interface NoWrapFieldProps extends FieldProps {}
 
-  static propTypes = {
-    ...Field.propTypes
-  }
+export default class NoWrapField extends Field<NoWrapFieldProps> {
 
   static jsClass = 'NoWrapField';
 
@@ -14,5 +12,4 @@ export default class NoWrapField extends Field {
 
   render() {
     return this.content();
-  }
-};
+  }};

--- a/src/js/forms/fields/pagination-field.tsx
+++ b/src/js/forms/fields/pagination-field.tsx
@@ -1,16 +1,29 @@
 import React from "react";
-import PropTypes from "prop-types";
 
-import Field from "./field";
+import Field, { FieldProps } from "./field";
 
-export default class PaginationField extends Field {
+export interface PaginationFieldTexts {
+  first: string;
+  previus: string;
+  next: string;
+  last: string;
+  pages: string;
+  goto: string;
+}
+
+export interface PaginationFieldProps extends FieldProps {
+  total?: number;
+  firstBtn?: boolean;
+  previusBtn?: boolean;
+  nextBtn?: boolean;
+  lastBtn?: boolean;
+  texts?: PaginationFieldTexts;
+}
+
+export default class PaginationField extends Field<PaginationFieldProps> {
 
   static jsClass = 'PaginationField';
-  static propTypes = {
-    ...Field.propTypes,
-    total: PropTypes.number.isRequired
-  }
-  static defaultProps = {
+  static defaultProps: Partial<PaginationFieldProps> = {
     ...Field.defaultProps,
     total: 1,
     default: 1,

--- a/src/js/forms/form.tsx
+++ b/src/js/forms/form.tsx
@@ -1,22 +1,21 @@
 import React, { createRef } from "react";
-import PropTypes from 'prop-types';
 
 import { randomS4, eventHandler } from "dbl-utils";
 
-import Component from "../component";
+import Component, { ComponentProps } from "../component";
 import fieldComponents from "./fields";
 
-export default class Form extends Component {
+export interface FormProps extends ComponentProps {
+  label?: string;
+  labelClasses?: string;
+  fieldClasses?: string;
+  fields?: any[];
+}
+
+export default class Form extends Component<FormProps> {
 
   static jsClass = 'Form';
-  static propTypes = {
-    ...Component.propTypes,
-    label: PropTypes.string,
-    labelClasses: PropTypes.string,
-    fieldClasses: PropTypes.string,
-    fields: PropTypes.array
-  }
-  static defaultProps = {
+  static defaultProps: Partial<FormProps> = {
     ...Component.defaultProps,
     fieldClasses: 'mb-3',
     fields: []

--- a/src/js/forms/groups/group.tsx
+++ b/src/js/forms/groups/group.tsx
@@ -1,20 +1,19 @@
 import React from "react";
-import PropTypes from 'prop-types';
 
 import fieldComponents from "../fields";
-import Component from "../../component";
+import Component, { ComponentProps } from "../../component";
 
-export default class Group extends Component {
+export interface GroupProps extends ComponentProps {
+  label?: string;
+  labelClasses?: string;
+  fieldClasses?: string;
+  fields?: any[];
+}
+
+export default class Group extends Component<GroupProps> {
 
   static jsClass = 'Group';
-  static propTypes = {
-    ...Component.propTypes,
-    label: PropTypes.string,
-    labelClasses: PropTypes.string,
-    fieldClasses: PropTypes.string,
-    fields: PropTypes.array
-  }
-  static defaultProps = {
+  static defaultProps: Partial<GroupProps> = {
     ...Component.defaultProps,
     fieldClasses: 'mb-3',
     fields: []

--- a/src/js/tables/table.tsx
+++ b/src/js/tables/table.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, { createRef } from "react";
 
 import {
@@ -10,13 +9,48 @@ import {
   splitAndFlat
 } from "dbl-utils";
 
-import { ptClasses } from "../prop-types";
 import fields from "../forms/fields";
 import Icons from "@farm-js/react-goat/media/icons";
 import Action from "../actions/action";
 import JsonRender from "../json-render";
-import Component from "../component";
+import Component, { ComponentProps } from "../component";
 import FloatingContainer from '@farm-js/react-goat/containers/floating-container';
+
+export interface HeaderCellProps {
+  col?: any;
+  icons?: any;
+  orderable?: boolean;
+  classes?: string | string[] | Record<string, any>;
+  headerClasses?: string | string[] | Record<string, any>;
+  orderClasses?: string | string[] | Record<string, any>;
+  orderActiveClasses?: string | string[] | Record<string, any>;
+  dropFilters: Record<string, any>;
+  headerRefs: Record<string, any>;
+  tableName?: string;
+  vertical?: boolean;
+}
+
+export interface TableProps extends ComponentProps {
+  colClasses?: string | string[] | Record<string, any>;
+  headerClasses?: string | string[] | Record<string, any>;
+  tableClasses?: string | string[] | Record<string, any>;
+  orderClasses?: string | string[] | Record<string, any>;
+  orderActiveClasses?: string | string[] | Record<string, any>;
+  columns?: any;
+  data?: any;
+  hover?: any;
+  icons?: any;
+  mapCells?: any;
+  mapRows?: any;
+  mutations?: any;
+  onChange?: any;
+  orderable?: any;
+  striped?: any;
+  vertical?: boolean;
+  headerCustom?: any;
+  columnsCustom?: any;
+  footerCustom?: any;
+}
 
 /**
  * @typedef {Object} FormatOptions
@@ -142,33 +176,7 @@ export const addFormatTemplates = (newTemplates = {}) => {
  * @class HeaderCell
  * @extends {React.Component}
  */
-export class HeaderCell extends React.Component {
-
-  static propTypes = {
-    col: PropTypes.any,
-    icons: PropTypes.any,
-    orderable: PropTypes.bool,
-    classes: PropTypes.oneOfType([
-      PropTypes.string, PropTypes.object,
-      PropTypes.arrayOf(PropTypes.string)
-    ]),
-    headerClasses: PropTypes.oneOfType([
-      PropTypes.string, PropTypes.object,
-      PropTypes.arrayOf(PropTypes.string)
-    ]),
-    orderClasses: PropTypes.oneOfType([
-      PropTypes.string, PropTypes.object,
-      PropTypes.arrayOf(PropTypes.string)
-    ]),
-    orderActiveClasses: PropTypes.oneOfType([
-      PropTypes.string, PropTypes.object,
-      PropTypes.arrayOf(PropTypes.string)
-    ]),
-    dropFilters: PropTypes.object.isRequired,
-    headerRefs: PropTypes.object.isRequired,
-    tableName: PropTypes.string,
-    vertical: PropTypes.bool
-  }
+export class HeaderCell extends React.Component<HeaderCellProps> {
 
   static jsClass = 'HeaderColumn';
   static defaultProps = {
@@ -385,34 +393,12 @@ export class HeaderCell extends React.Component {
 * @class Table
 * @extends {Component}
 */
-export default class Table extends Component {
+export default class Table extends Component<TableProps> {
 
   static jsClass = 'Table';
   static slots = ['headerCustom', 'columnsCustom', 'footerCustom'];
 
-  static propTypes = {
-    ...Component.propTypes,
-    colClasses: ptClasses,
-    headerClasses: ptClasses,
-    tableClasses: ptClasses,
-    orderClasses: ptClasses,
-    orderActiveClasses: ptClasses,
-    columns: PropTypes.any,
-    data: PropTypes.any,
-    hover: PropTypes.any,
-    icons: PropTypes.any,
-    mapCells: PropTypes.any,
-    mapRows: PropTypes.any,
-    mutations: PropTypes.any,
-    onChange: PropTypes.any,
-    orderable: PropTypes.any,
-    striped: PropTypes.any,
-    vertical: PropTypes.bool,
-    headerCustom: PropTypes.any,
-    columnsCustom: PropTypes.any,
-    footerCustom: PropTypes.any,
-  }
-  static defaultProps = {
+  static defaultProps: Partial<TableProps> = {
     ...Component.defaultProps,
     data: [],
     striped: true,


### PR DESCRIPTION
## Summary
- drop PropTypes usage across several components
- introduce new `Props` interfaces and generic component declarations

## Testing
- `yarn build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ee74cff648326908984833de30a01

## Summary by Sourcery

Migrate from PropTypes to TypeScript by defining new interfaces for component props and updating component declarations accordingly.

Enhancements:
- Remove PropTypes imports and static propTypes definitions across multiple components
- Introduce TypeScript interfaces for props (e.g., TableProps, FieldProps, OffcanvasContainerProps, etc.)
- Make component classes generic over their new Props interfaces and type defaultProps as Partial<Props>